### PR TITLE
Configure bind interface by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,12 +75,12 @@ table inet filter {
 ### Binary
 
 1. Do one of the following to get your binary.
-        - Get the latest prebuild binary for your architecture from the [releases](https://github.com/Cybersecurity-and-Enterprise-Security/bee/releases) (note that this is currently specifically build for the latest Debian, so it might not work on your local system).
-        - [Build](#build) the binary locally.
-1. Currently, the binary requires elevated privileges because of the network operations. Hence, either run the binary with `sudo`, or set the necessary capabilities using `sudo setcap cap_net_admin,cap_net_raw=eip ./bee`. Replace `ipAddress` with the IP address you want the Bee to listen on. Usually, this will be your public facing IP address.
+    - Get the latest prebuild binary for your architecture from the [releases](https://github.com/Cybersecurity-and-Enterprise-Security/bee/releases) (note that this is currently specifically build for the latest Debian, so it might not work on your local system).
+    - [Build](#build) the binary locally.
+1. Currently, the binary requires elevated privileges because of the network operations. Hence, either run the binary with `sudo`, or set the necessary capabilities using `sudo setcap cap_net_admin,cap_net_raw=eip ./bee`. **Note**: The program choses an IP address to bind to by default [based on your default routes](cmd/bee/args.go). Most of the times, this should be correct. If your host retrieves the external traffic on a separate IP address, adjust it using the `-bind <ipAddress>` flag.
 
     ```bash
-    sudo ./bee -bind <ipAddress>
+    sudo ./bee
     ```
 
 1. Finally, you should be asked to input the registration token copied above.

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ table inet filter {
 1. Do one of the following to get your binary.
         - Get the latest prebuild binary for your architecture from the [releases](https://github.com/Cybersecurity-and-Enterprise-Security/bee/releases) (note that this is currently specifically build for the latest Debian, so it might not work on your local system).
         - [Build](#build) the binary locally.
-1. Currently, the binary requires elevated privileges because of the network operations. Hence, either run the binary with `sudo`, or set the necessary capabilities using `sudo setcap cap_net_admin,cap_sys_admin,cap_net_raw=eip ./bee`. Replace `ipAddress` with the IP address you want the Bee to listen on. Usually, this will be your public facing IP address.
+1. Currently, the binary requires elevated privileges because of the network operations. Hence, either run the binary with `sudo`, or set the necessary capabilities using `sudo setcap cap_net_admin,cap_net_raw=eip ./bee`. Replace `ipAddress` with the IP address you want the Bee to listen on. Usually, this will be your public facing IP address.
 
     ```bash
     sudo ./bee -bind <ipAddress>

--- a/cmd/bee/args.go
+++ b/cmd/bee/args.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"net"
+	"net/netip"
+	"os"
+
+	"github.com/vishvananda/netlink"
+)
+
+type arguments struct {
+	BindAddress       netip.Addr
+	BeekeeperBasePath string
+}
+
+func parseArgs() arguments {
+	var result arguments
+	var bindAddress string
+
+	if os.Getenv("BEE_MODE") == "development" {
+		flag.StringVar(&result.BeekeeperBasePath, "beekeeper", "http://localhost:3001/v1", "base path of the beekeeper")
+	} else {
+		result.BeekeeperBasePath = "https://beekeeper.thebeelab.net/v1"
+	}
+
+	flag.StringVar(&bindAddress, "bind", "", "address to bind listener to")
+	flag.Parse()
+
+	if bindAddress == "" {
+		defaultAddress, err := defaultListenIP()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Getting default listen IP failed: %v\n", err)
+			fmt.Fprintln(os.Stderr, "You need to specify a bind address using -bind.")
+			flag.Usage()
+			os.Exit(1)
+		}
+		bindAddress = defaultAddress
+	}
+
+	result.BindAddress = netip.MustParseAddr(bindAddress)
+	return result
+}
+
+func defaultListenIP() (string, error) {
+	routes, err := netlink.RouteGet(net.ParseIP("1.1.1.1"))
+	if err != nil {
+		return "", fmt.Errorf("getting route to 1.1.1.1: %w", err)
+	}
+
+	if len(routes) == 0 {
+		return "", fmt.Errorf("no default route found")
+	}
+
+	return routes[0].Src.String(), nil
+}

--- a/cmd/bee/main.go
+++ b/cmd/bee/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"flag"
 	"fmt"
 	"net/netip"
 	"os"
@@ -22,38 +21,10 @@ func init() {
 	log.SetLevel(log.DebugLevel)
 }
 
-type arguments struct {
-	BindAddress       netip.Addr
-	BeekeeperBasePath string
-}
-
-func parseArgs() arguments {
-	var result arguments
-	var bindAddress string
-
-	if os.Getenv("BEE_MODE") == "development" {
-		flag.StringVar(&result.BeekeeperBasePath, "beekeeper", "http://localhost:3001/v1", "base path of the beekeeper")
-	} else {
-		result.BeekeeperBasePath = "https://beekeeper.thebeelab.net/v1"
-	}
-
-	flag.StringVar(&bindAddress, "bind", "", "address to bind listener to")
-	flag.Parse()
-
-	if bindAddress == "" {
-		fmt.Fprintln(os.Stderr, "You need to specify a bind address using -bind.")
-		flag.Usage()
-		os.Exit(1)
-	}
-
-	result.BindAddress = netip.MustParseAddr(bindAddress)
-	return result
-}
-
 func main() {
 	args := parseArgs()
 
-	log.Info("Starting...")
+	log.WithField("BindAddress", args.BindAddress).Info("Starting Bee")
 
 	err := run(args.BindAddress, args.BeekeeperBasePath)
 	if err != nil {

--- a/cmd/bee/main.go
+++ b/cmd/bee/main.go
@@ -17,12 +17,9 @@ import (
 
 const loopRestartInterval = 1 * time.Second
 
-func init() {
-	log.SetLevel(log.DebugLevel)
-}
-
 func main() {
 	args := parseArgs()
+	log.SetLevel(args.LogLevel)
 
 	log.WithField("BindAddress", args.BindAddress).Info("Starting Bee")
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,7 +4,6 @@ services:
   bee:
     image: ghcr.io/cybersecurity-and-enterprise-security/bee:main
     restart: always
-    command: -bind ...
     network_mode: host
     cap_add:
       - NET_ADMIN

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -8,7 +8,6 @@ services:
     network_mode: host
     cap_add:
       - NET_ADMIN
-      - SYS_ADMIN
     volumes:
       - data:/etc/bee
     environment:

--- a/internal/heartbeat/heartbeat.go
+++ b/internal/heartbeat/heartbeat.go
@@ -57,8 +57,12 @@ func (h *Heartbeat) UpdateForwardings(ctx context.Context) {
 		return
 	}
 
-	h.forwarder.SetDefaultBeehiveAddress(info.DefaultBeehive)
-	log.WithField("beehive", info.DefaultBeehive).Debug("updated default beehive")
+	err = h.forwarder.SetDefaultBeehiveAddress(info.DefaultBeehive)
+	if err != nil {
+		log.WithError(err).Error("Error updating default beehive address")
+	} else {
+		log.WithField("beehive", info.DefaultBeehive).Debug("Updated default beehive")
+	}
 
 	newBeehives := make([]forward.WireguardBeehive, 0, len(info.Beehives))
 	for _, beehive := range info.Beehives {

--- a/pkg/forward/forwarder.go
+++ b/pkg/forward/forwarder.go
@@ -312,6 +312,6 @@ func (f *Forwarder) UpdateForwardingRules(newRules []ForwardingRule) {
 	f.rules.UpdateForwardingRules(newRules)
 }
 
-func (f *Forwarder) SetDefaultBeehiveAddress(addr string) {
-	f.rules.SetDefaultBeehiveAddress(addr)
+func (f *Forwarder) SetDefaultBeehiveAddress(addr string) error {
+	return f.rules.SetDefaultBeehiveAddress(addr)
 }

--- a/pkg/forward/rules.go
+++ b/pkg/forward/rules.go
@@ -2,6 +2,7 @@ package forward
 
 import (
 	"errors"
+	"fmt"
 	"net/netip"
 	"runtime"
 	"sync"
@@ -40,13 +41,20 @@ func NewForwardingRuleStore() *ForwardingRuleStore {
 	}
 }
 
-func (f *ForwardingRuleStore) SetDefaultBeehiveAddress(addr string) {
+func (f *ForwardingRuleStore) SetDefaultBeehiveAddress(addr string) error {
 	f.Lock()
 	defer f.Unlock()
 
-	addrPort := netip.AddrPortFrom(netip.MustParseAddr(addr), GenevePort)
+	parsed, err := netip.ParseAddr(addr)
+	if err != nil {
+		return fmt.Errorf("parsing default beehive address: %w", err)
+	}
+
+	addrPort := netip.AddrPortFrom(parsed, GenevePort)
 
 	f.defaultBeehive = &addrPort
+
+	return nil
 }
 
 func (f *ForwardingRuleStore) UpdateForwardingRules(newRules []ForwardingRule) {

--- a/pkg/forward/setup.go
+++ b/pkg/forward/setup.go
@@ -20,7 +20,7 @@ func (f *Forwarder) setupNetNS() error {
 		return fmt.Errorf("get init netns: %w", err)
 	}
 
-	netns, err := netlink.NewHandleAt(netnsFd)
+	netns, err := netlink.NewHandleAt(netns.None())
 	if err != nil {
 		return fmt.Errorf("get handle for init netns: %w", err)
 	}


### PR DESCRIPTION
Amongst some other little fixes and improvements, this chooses the bind address of the bee by default, as described in #5.

Closes #5 