### PR TITLE
Fix MTU issue when sending packets form the bee to the attacker

### DIFF
--- a/pkg/forward/utils.go
+++ b/pkg/forward/utils.go
@@ -33,3 +33,10 @@ func interfaceOfAddress(address netip.Addr) (*net.Interface, error) {
 	}
 	return nil, fmt.Errorf("no interface with address %s", address.String())
 }
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}


### PR DESCRIPTION
Fragment packets from the beehive to the attacker if they are larger than the interface MTU. Because sockets with the IP_HDRINCL option never fragment outgoing packets, we have to do it manually.