### PR TITLE
fix: fragmentation not setting more fragments bit

### DIFF
--- a/pkg/forward/forwarder.go
+++ b/pkg/forward/forwarder.go
@@ -328,7 +328,7 @@ func (f *Forwarder) BeehiveToAttackerLoop(ctx context.Context) error {
 			}
 			ipv4.Flags &^= layers.IPv4DontFragment
 			ipv4.FragOffset = uint16(offset / 8)
-			if offset+fragmentSize < maxPayloadSize {
+			if offset+fragmentSize <= maxPayloadSize {
 				ipv4.Flags |= layers.IPv4MoreFragments
 			} else {
 				ipv4.Flags &^= layers.IPv4MoreFragments


### PR DESCRIPTION
The previous check for setting the more fragments bit was a little off, as it would sometimes not set the MF bit leading to the packets not arriving properly.