### PR TITLE
Fix unrecognized ports and teardown

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,10 @@ Also, make sure that your endpoint configuration in the frontend blocks your ope
 1. Create a new endpoint in the Beekeeper using the frontend or API directly.
 1. Copy the registration token.
 1. **Note**: Both versions (Docker and binary) choose an IP address to bind to by default [based on your default routes](cmd/bee/args.go). Usually, this should be correct. If your host retrieves the external traffic on a separate IP address, adjust it using the `-bind <ipAddress>` flag.
-1. If you do not want to forward specific ports, use the `-ignoredTcpPorts` and `-ignoredUdpPorts` variables. These are comma-separated lists of port ranges, where each range is only one port or `start-end`, e.g. `1-1023,2222`.
+1. If you do not want to forward specific ports, e.g. if you need **SSH access** to the bee via its bound ip, use the `-ignoredTcpPorts` and `-ignoredUdpPorts` command line arguments. These are comma-separated lists of port ranges, where each range is only one port or `start-end`, e.g. `1-1023,2222`.
+    In addition to these, the bee looks for listening sockets on the address at startup and does not forward these. You can see the ignored ports in the log output at startup.
+
+**IF YOUR PRIMARY ACCESS TO THE MACHINE IS THROUGH THE BOUND ADDRESS, DOUBLE-CHECK THAT `-ignoredTcpPorts` INCLUDES ALL PORTS YOU NEED FOR ACCESS. YOU MIGHT BE LOCKED OUT OTHERWISE.**
 
 ### Docker (recommended)
 

--- a/cmd/bee/main.go
+++ b/cmd/bee/main.go
@@ -47,7 +47,7 @@ func run(args arguments) error {
 	}
 
 	if !args.DisableNftables {
-		err = nftables.ConfigureNftables(args.BindAddress.String(), args.IgnoredTCPPorts, args.IgnoredUDPPorts)
+		err = nftables.ConfigureNftables(args.BindAddress, args.IgnoredTCPPorts, args.IgnoredUDPPorts)
 		if err != nil {
 			return fmt.Errorf("configuring nftables: %w", err)
 		}

--- a/cmd/bee/main.go
+++ b/cmd/bee/main.go
@@ -122,6 +122,8 @@ func run(args arguments) error {
 	if ok {
 		log.WithField("signal", sig).Info("Received signal, shutting down")
 	}
+	// Cancel before the other closing functions run.
+	cancel()
 
 	return nil
 }

--- a/compose.yaml
+++ b/compose.yaml
@@ -9,6 +9,7 @@ services:
       - data:/etc/bee
     environment:
       - BEE_REGISTRATION_TOKEN=...
+    command: ["-ignoredTcpPorts", "", "-ignoredUdpPorts", ""]
 
 volumes:
   data:


### PR DESCRIPTION
This PR fixes problems encountered when deploying the bee to our staging environment.

### Listening port detection

Now, a port is no longer captured when there is a socket listening on it on ipv6. This is because these sockets may also listen to ipv4-mapped ipv4 addresses. See `ipv6 (7)` with keyword `IPV6_V6ONLY` for more details.

### Tear-down

When stopping the bee, `attackerCapture.Close` blocks for some time (forever?) until the context is canceled. However, because of the `defer` order in `run`, the context was only canceled after the forwarder had closed. To resolve this deadlock, (1) we explicitly cancel the context after terminating due to a signal and (2) we continue the tear-down while the nflog handle is closing.  

### Docs

We added a few words to indicate that users must pay attention to the ignored ports, or else they might lock themselves out.